### PR TITLE
Fix Picsum URL

### DIFF
--- a/React Native Workshop.md
+++ b/React Native Workshop.md
@@ -542,7 +542,7 @@ const DetailsScreen = () => {
       <View style={styles.speaker}>
         <Image
           style={styles.avatar}
-          source={{ uri: "https://i.picsum.photos/id/365/80/80.jpg" }}
+          source={{ uri: "https://picsum.photos/id/365/80/80.jpg" }}
         />
         <View>
           <Text style={styles.speakerName}>Speaker name</Text>


### PR DESCRIPTION
The current URL has a `Invalid parameters` response. By removing the `i` subdomain, we are able to retrieve the avatar.