### PR TITLE
Update React Native Workshop.md - fix broken avatar link

### DIFF
--- a/React Native Workshop.md
+++ b/React Native Workshop.md
@@ -542,7 +542,7 @@ const DetailsScreen = () => {
       <View style={styles.speaker}>
         <Image
           style={styles.avatar}
-          source={{ uri: "https://i.picsum.photos/id/365/80/80.jpg" }}
+          source={{ uri: "https://picsum.photos/id/365/80/80.jpg" }}
         />
         <View>
           <Text style={styles.speakerName}>Speaker name</Text>


### PR DESCRIPTION
The avatar link https://i.picsum.photos/id/365/80/80.jpg causes an "Invalid parameters" error, replacing with https://picsum.photos/id/365/80/80.jpg seems to fix the problem.