### PR TITLE
Update app name and small typo fix

### DIFF
--- a/React Native Workshop.md
+++ b/React Native Workshop.md
@@ -57,9 +57,9 @@ Next, install the Expo CLI globally by running the following command. You can al
 npm install -g expo-cli
 ```
 
-## Expo client app
+## Expo Go app
 
-Install the "Expo" client app on your iOS or Android device and create an account. Log into your account in your terminal window by running
+Install the "Expo Go" app on your iOS or Android device and create an account. Log into your account in your terminal window by running
 
 
 ``` Bash
@@ -1168,7 +1168,7 @@ const HomeScreen = (props) => {
 ..
 ```
 
-`navigate` is an available function on the `props.navigation` object. We can cal this with the name of the route that we'd like to move the user to.
+`navigate` is an available function on the `props.navigation` object. We can call this with the name of the route that we'd like to move the user to.
 
 Update the `TouchableOpacity` button to include the `onPress` prop and pass in an anonymous function which navigates the user to the "Schedule" screen.
 


### PR DESCRIPTION
This tutorial is awesome! Thank you!

### What

- Update the app name to Expo Go: the most recent version changes the name to Expo Go (and I confirmed its both Android and iOs)
- Fix a small typo "cal" -> "call"

### Why

I almost downloaded a random other app that's call Expo but is not the right one. I think this clarification would make it easier for those unfamiliar with Expo grab the correct app in the app store.

I also noticed the avatar links didn't seem to work, but I don't know where they are now so I couldn't fix that :)